### PR TITLE
dragItems, panHandler, getDragItems and domElement

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,15 @@ paper.zpd(function (err, paper) {
 
 ### options
 
-#### zoom
+#### pan
 
     true or false: enable or disable panning (default true)
+    
+#### panHandler
 
-#### pad
+    true or false: sets the background as the only element that can pan the entire zpd object
+
+#### zoom
 
     true or false: enable or disable zooming (default true)
 

--- a/README.md
+++ b/README.md
@@ -122,11 +122,12 @@ paper.zpd('origin');
     back to the origin location
 
 #### paper.zpd('domElement')
-    get the dom Element of zpd to make it easy to add new elements inside the zpd <g> node
 
 ```js
 paper.zpd('domElement').appendChild(paper.circle(10,10,10).node);    
 ```
+
+    get the dom Element of zpd to make it easy to add new elements inside the zpd <g> node
 
 #### zoomTo
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,22 @@ paper.zpd(function (err, paper) {
 
     array: min and max zoom level threshold [min, max] (default null)
 
+#### dragItems
+
+    object: object of snap element ids.  keys are id's of the object
+
+```js
+    var c1 = paper.circle(100,  100, 3);
+    var c2 = paper.circle(200,  100, 3);
+    var c2 = paper.circle(300,  100, 3);
+    var myDragItems = {};
+    myDragItems[c1.id] = c1.id;
+    myDragItems[c2.id] = c2.id;
+    myDragItems[c3.id] = c3.id;
+
+    paper.zpd({drag:true, dragItems: myDragItems});
+```    
+
 ### More
 
 #### paper.zpd('destroy')
@@ -104,6 +120,13 @@ paper.zpd({ load: {a:0.6787972450256348,b:0,c:0,d:0.6787972450256348,e:159.63783
 paper.zpd('origin');
 ```
     back to the origin location
+
+#### paper.zpd('domElement')
+    get the dom Element of zpd to make it easy to add new elements inside the zpd <g> node
+
+```js
+paper.zpd('domElement').appendChild(paper.circle(10,10,10).node);    
+```
 
 #### zoomTo
 

--- a/snap.svg.zpd.js
+++ b/snap.svg.zpd.js
@@ -554,7 +554,7 @@
 
                 case situationState.save:
 
-                    var g = document.getElementById(snapsvgzpd.uniqueIdPrefix + self.id);
+                    var g = zpdElement.element.node;;
 
                     var returnValue = g.getCTM();
 
@@ -577,7 +577,7 @@
 
                     return;
                 case situationState.domElement:
-                    return document.getElementById(snapsvgzpd.uniqueIdPrefix + self.id);
+                    return zpdElement.element.node;
             }
         };
 


### PR DESCRIPTION
Added:
dragItems: allows you to specify which items in zpd are draggable
panHandler: true:false, sets the background layer as the only element that can pan the whole zpd object

getters:
domElement: quick access to the domElement - useful for easily adding and removing items from zpd
getDragItems: you can use this to get the current dragItems and add another item to the list then reinit.

I also did a mini refactor of the code to make it a bit more readable.