### PR TITLE
add toggle enabled functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ paper.zoomToElement(paper.select('#my-element'), 3000, mina.bounce, function (er
     console.log(paper);
 });
 ```
-    element (must be Snap Element), interval (ms optional), mina (optional), callback (optional)
+    element (must be Snap Element), filling (req'd -> percent of screen height or width to fill, 1 being whole screen), interval (ms optional), mina (optional), callback (optional)
 
 
 #### panTo

--- a/README.md
+++ b/README.md
@@ -151,6 +151,15 @@ paper.panTo(a, x, y, mina.bounce, function (err, paper) {
 ```
     a (rotate degree) x, y (original point), interval (ms optional), mina (optional), callback (optional)
 
+#### toggleZpdEnabled
+By default, zpd is enabled, but you can toggle or set its activation using this function.  
+
+```js
+paper.toggleZpdEnabled();  // toggle off 
+paper.toggleZpdEnabled(true); // sets to on
+paper.toggleZpdEnabled(false); // sets to off
+```
+
 ### Experimental: Edit
 to add an element to the transformation matrix.
 select the group that contains the matrix

--- a/README.md
+++ b/README.md
@@ -129,6 +129,16 @@ paper.zoomTo(1.5, 3000, mina.bounce, function (err, paper) {
 ```
     zoom (must > 0), interval (ms optional), mina (optional), callback (optional)
 
+#### zoomToElement
+
+```js
+paper.zoomToElement(paper.select('#my-element'), 3000, mina.bounce, function (err, paper) {
+    console.log(paper);
+});
+```
+    element (must be Snap Element), interval (ms optional), mina (optional), callback (optional)
+
+
 #### panTo
 
 ```js
@@ -140,6 +150,8 @@ paper.panTo(100, 100, 3000, mina.bounce, function (err, paper) {
 });
 ```
     x, y (can be number or string with + -), interval (ms optional), mina (optional), callback (optional)
+
+
 
 #### rotate
 

--- a/index.html
+++ b/index.html
@@ -77,6 +77,7 @@
 
             // run initializer
             applyZpd();
+            paper.attr('style', "postion:absolute; top:300px; left:300px");
 
 
             // UI improvement needed

--- a/snap.svg.zpd.js
+++ b/snap.svg.zpd.js
@@ -156,8 +156,8 @@
 
             var p = svgNode.node.createSVGPoint();
 
-            p.x = event.clientX;
-            p.y = event.clientY;
+            p.x = event.clientX - parseFloat(window.getComputedStyle(svgNode.node,null).getPropertyValue('left'));
+            p.y = event.clientY - parseFloat(window.getComputedStyle(svgNode.node,null).getPropertyValue('top'));
 
             return p;
         };

--- a/snap.svg.zpd.js
+++ b/snap.svg.zpd.js
@@ -729,7 +729,7 @@
         var roundToClosest = function(value, factor){
             return Math.round(value/factor) * factor;
         }
-        var zoomToElement = function(el, filling, interval, ease, cb){
+        var zoomToBB = function(bbox, filling, interval, ease, cb){
             var zpdElement = snapsvgzpd.dataStore[this.id].element,
                 rootSvg = snapsvgzpd.dataStore[this.id].data.root,
                 width = rootSvg.clientWidth,
@@ -737,10 +737,9 @@
                 options = snapsvgzpd.dataStore[this.id].options,
                 minScale = (!!options.zoomThreshold)? options.zoomThreshold[0] : Number.NEGATIVE_INFINITY,
                 maxScale = (!!options.zoomThreshold)? options.zoomThreshold[1] : Number.POSITIVE_INFINITY,
-                bbox = el.getBBox(),
                 x = (bbox.x + bbox.x2) / 2,
                 y = (bbox.y + bbox.y2) / 2,
-                realScale = filling / Math.max(bbox.w / width, bbox.h / height),
+                realScale = filling || 1 / Math.max(bbox.w / width, bbox.h / height),
                 scale = roundToClosest(Math.min(Math.max(realScale, minScale), maxScale), options.zoomScale),
                 translateX = width / 2 - scale * x,
                 translateY = height / 2 - scale * y,
@@ -761,12 +760,19 @@
             }
         }
 
+        var zoomToElement = function(el, filling, interval, ease, cb){
+            this.zoomToBB(el.getBBox(), filling, interval, ease, cb);
+        }
+         
+
         Paper.prototype.zpd = zpd;
         Paper.prototype.zoomTo = zoomTo;
         Paper.prototype.panTo = panTo;
         Paper.prototype.rotate = rotate;
         Paper.prototype.toggleZpdEnabled = toggleEnabled;
         Paper.prototype.zoomToElement = zoomToElement;
+        Paper.prototype.zoomToBB = zoomToBB;
+
 
         /** More Features to add (click event) help me if you can **/
         // Element.prototype.panToCenter = panToCenter; // arg (ease, interval, cb)

--- a/snap.svg.zpd.js
+++ b/snap.svg.zpd.js
@@ -729,7 +729,12 @@
         var roundToClosest = function(value, factor){
             return Math.round(value/factor) * factor;
         }
+
+        var roundToClosestScale = function(value, factor){
+            return 1/roundToClosest(1/value, factor);
+        }
         var zoomToBB = function(bbox, filling, interval, ease, cb){
+            var thisFilling = filling || 1;
             var zpdElement = snapsvgzpd.dataStore[this.id].element,
                 rootSvg = snapsvgzpd.dataStore[this.id].data.root,
                 width = rootSvg.clientWidth,
@@ -739,8 +744,8 @@
                 maxScale = (!!options.zoomThreshold)? options.zoomThreshold[1] : Number.POSITIVE_INFINITY,
                 x = (bbox.x + bbox.x2) / 2,
                 y = (bbox.y + bbox.y2) / 2,
-                realScale = filling || 1 / Math.max(bbox.w / width, bbox.h / height),
-                scale = roundToClosest(Math.min(Math.max(realScale, minScale), maxScale), options.zoomScale),
+                realScale =  thisFilling / Math.max(bbox.w / width, bbox.h / height),
+                scale = roundToClosestScale(Math.min(Math.max(realScale, minScale), maxScale), options.zoomScale),
                 translateX = width / 2 - scale * x,
                 translateY = height / 2 - scale * y,
 

--- a/snap.svg.zpd.js
+++ b/snap.svg.zpd.js
@@ -700,11 +700,40 @@
             }
         }
 
+        function zoomToBBox(elem) {
+        };
+
+        var zoomToElement = function(el, filling, interval, ease, cb){
+            var zpdElement = snapsvgzpd.dataStore[this.id].element,
+                rootSvg = snapsvgzpd.dataStore[this.id].data.root,
+                width = rootSvg.clientWidth,
+                height = rootSvg.clientHeight,
+                bbox = el.getBBox(),
+                x = (bbox.x + bbox.x2) / 2,
+                y = (bbox.y + bbox.y2) / 2,
+                scale = filling / Math.max(bbox.w / width, bbox.h / height),
+                translateX = width / 2 - scale * x,
+                translateY = height / 2 - scale * y,
+                m = Snap.matrix(scale, 0, 0, scale, translateX, translateY);
+            // paper.animate({ transform: m }, 400, mina.easeout);
+
+            if (interval === 0 || interval === undefined){
+                zpdElement.transform(m);
+            }else{
+                zpdElement.animate({ transform: m }, interval, ease || null, function () {
+                    if (cb) {
+                        cb(null, zpdElement);
+                    }
+                });
+            }
+        }
+
         Paper.prototype.zpd = zpd;
         Paper.prototype.zoomTo = zoomTo;
         Paper.prototype.panTo = panTo;
         Paper.prototype.rotate = rotate;
         Paper.prototype.toggleZpdEnabled = toggleEnabled;
+        Paper.prototype.zoomToElement = zoomToElement;
 
         /** More Features to add (click event) help me if you can **/
         // Element.prototype.panToCenter = panToCenter; // arg (ease, interval, cb)

--- a/snap.svg.zpd.js
+++ b/snap.svg.zpd.js
@@ -702,18 +702,24 @@
 
         function zoomToBBox(elem) {
         };
-
+        var roundDownToClosest = function(value, factor){
+            Math.floor(value/factor) * factor
+        }
         var zoomToElement = function(el, filling, interval, ease, cb){
             var zpdElement = snapsvgzpd.dataStore[this.id].element,
                 rootSvg = snapsvgzpd.dataStore[this.id].data.root,
                 width = rootSvg.clientWidth,
                 height = rootSvg.clientHeight,
+                minScale = (!!zpdElement.options.zoomThreshold)? zpdElement.options.zoomThreshold[0] : Math.NEGATIVE_INFINITY,
+                maxScale = (!!zpdElement.options.zoomThreshold)? zpdElement.options.zoomThreshold[1] : Math.POSITIVE_INFINITY,
                 bbox = el.getBBox(),
                 x = (bbox.x + bbox.x2) / 2,
                 y = (bbox.y + bbox.y2) / 2,
-                scale = filling / Math.max(bbox.w / width, bbox.h / height),
+                realScale = filling / Math.max(bbox.w / width, bbox.h / height),
+                scale = roundDownToClosest(Math.min(Math.max(realScale, minScale), maxScale), zpdElement.options.zoomScale),
                 translateX = width / 2 - scale * x,
                 translateY = height / 2 - scale * y,
+
                 m = Snap.matrix(scale, 0, 0, scale, translateX, translateY);
             // paper.animate({ transform: m }, 400, mina.easeout);
 

--- a/snap.svg.zpd.js
+++ b/snap.svg.zpd.js
@@ -152,13 +152,23 @@
         /**
          * Instance an SVGPoint object with given event coordinates.
          */
+
+        var  _findPos = function findPos(obj) {
+          var curleft = curtop = 0;
+          if (obj.offsetParent) {
+            do {
+              curleft += obj.offsetLeft;
+              curtop += obj.offsetTop;
+            } while(obj = obj.offsetParent);
+          }
+          return [curleft,curtop];
+        };
+
         var _getEventPoint = function getEventPoint(event, svgNode) {
-
             var p = svgNode.node.createSVGPoint();
-
-            p.x = event.clientX - parseFloat(window.getComputedStyle(svgNode.node,null).getPropertyValue('left'));
-            p.y = event.clientY - parseFloat(window.getComputedStyle(svgNode.node,null).getPropertyValue('top'));
-
+            var svgPos = _findPos(svgNode.node);
+            p.x = event.clientX - svgPos[0];
+            p.y = event.clientY - svgPos[1];
             return p;
         };
 

--- a/snap.svg.zpd.js
+++ b/snap.svg.zpd.js
@@ -740,7 +740,7 @@
 
             if (interval === 0 || interval === undefined){
                 zpdElement.transform(m);
-                _viewChanged(snapsvgzpd.dataStore[self.id].options);
+                _viewChanged(options);
             }else{
                 zpdElement.animate({ transform: m }, interval, ease || null, function () {
                     _viewChanged(options);

--- a/snap.svg.zpd.js
+++ b/snap.svg.zpd.js
@@ -87,7 +87,8 @@
          */
         var snapsvgzpd = {
             uniqueIdPrefix: 'snapsvg-zpd-',     // prefix for the unique ids created for zpd
-            dataStore: {}                       // "global" storage for all our zpd elements
+            dataStore: {}    ,
+            enabled: true                   // "global" storage for all our zpd elements
         };
 
         /**
@@ -99,13 +100,13 @@
          * remove node parent but keep children
          */
         var _removeNodeKeepChildren = function removeNodeKeepChildren(node) {
-            if (!node.parentNode) {
+            if (!node.parentElement) {
                 return;
             }
             while (node.firstChild) {
-                node.parentNode.insertBefore(node.firstChild, node);
+                node.parentElement.insertBefore(node.firstChild, node);
             }
-            node.parentNode.removeChild(node);
+            node.parentElement.removeChild(node);
         };
 
         /**
@@ -266,7 +267,7 @@
         var _getHandlerFunctions = function getHandlerFunctions(zpdElement) {
 
             var handleMouseUp = function handleMouseUp (event) {
-
+                if (!snapsvgzpd.enabled) {return;}
                 if (event.preventDefault) {
                     event.preventDefault();
                 }
@@ -283,7 +284,7 @@
             };
 
             var handleMouseDown = function handleMouseDown (event) {
-
+                if (!snapsvgzpd.enabled) {return;}
                 if (event.preventDefault) {
                     event.preventDefault();
                 }
@@ -317,7 +318,7 @@
             };
 
             var handleMouseMove = function handleMouseMove (event) {
-
+                if (!snapsvgzpd.enabled) {return;}
                 if (event.preventDefault) {
                     event.preventDefault();
                 }
@@ -349,7 +350,7 @@
             };
 
             var handleMouseWheel = function handleMouseWheel (event) {
-
+                if (!snapsvgzpd.enabled) {return;}
                 if (!zpdElement.options.zoom) {
                     return;
                 }
@@ -456,7 +457,8 @@
                 zoom: true,         // enable or disable zooming (default enabled)
                 drag: false,        // enable or disable dragging (default disabled)
                 zoomScale: 0.2,     // define zoom sensitivity
-                zoomThreshold: null // define zoom threshold
+                zoomThreshold: null, // define zoom threshold
+                enabled: true
             };
 
             // the situation event of zpd, may be init, reinit, destroy, save, origin
@@ -690,10 +692,19 @@
             }
         };
 
+        var toggleEnabled = function(isEnabled){
+            if (isEnabled !== undefined){
+                snapsvgzpd.enabled = isEnabled;
+            }else{
+                snapsvgzpd.enabled = !snapsvgzpd.enabled;
+            }
+        }
+
         Paper.prototype.zpd = zpd;
         Paper.prototype.zoomTo = zoomTo;
         Paper.prototype.panTo = panTo;
         Paper.prototype.rotate = rotate;
+        Paper.prototype.toggleZpdEnabled = toggleEnabled;
 
         /** More Features to add (click event) help me if you can **/
         // Element.prototype.panToCenter = panToCenter; // arg (ease, interval, cb)

--- a/snap.svg.zpd.js
+++ b/snap.svg.zpd.js
@@ -396,7 +396,7 @@
                 }
 
                 zpdElement.data.stateTf = zpdElement.data.stateTf.multiply(k.inverse());
-                viewChanged(zpdElement.options);
+                _viewChanged(zpdElement.options);
             };
 
             return {
@@ -608,7 +608,7 @@
                 // get a reference to the element
                 var zpdElement = snapsvgzpd.dataStore[self.id].element;
                 var options = snapsvgzpd.dataStore[this.id].options;
-                
+
                 var currentTransformMatrix = zpdElement.node.getTransformToElement(rootSvgObject);
                 var currentZoom = currentTransformMatrix.a;
                 var originX = currentTransformMatrix.e;

--- a/zoomDemo.html
+++ b/zoomDemo.html
@@ -31,12 +31,16 @@
 
                 Snap.load('lib/malaysia.svg', function (data) {
                     container = document.getElementById('svg-container');
-                    svgNode = data.node.children[0]
+                    svgNode = data.node.children[0];
                     container.appendChild(svgNode);
                     paper = Snap(svgNode);
                     var bbox = paper.select('g').getBBox();
                     paper.attr({'height': bbox.h, 'width':bbox.w});
-                    paper.zpd();
+                    paper.zpd({
+                        'viewChanged':function(){
+                            console.log('view change');
+                        }
+                    });
                     // viewSelector('path[qs\\:layer="1301-Gross Building Area"]');
                     var ele = paper.selectAll('.land').forEach(function(el){
                         el.click(function(){

--- a/zoomDemo.html
+++ b/zoomDemo.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html>
+
+    <head>
+        <meta charset="utf-8"/>
+        <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+        <title>A zoom/pan/drag/rotate plugin for Snap.svg</title>
+        <style>
+            html, body { margin:0; padding:0; overflow:hidden }
+            svg { position:fixed; top:0; left:0; }
+            .dragText {
+                font-size: 100px;
+            }
+            .button {
+                position: fixed;
+                right: 50px;
+                bottom: 50px;
+                z-index: 100;
+            }
+        </style>
+
+        <script src="./lib/snap.svg.js"></script>
+        <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+        <script src="./snap.svg.zpd.js"></script>
+        <script>
+            var paper, container;
+
+
+            window.onload = function(){
+
+                Snap.load('lib/malaysia.svg', function (data) {
+                    container = document.getElementById('svg-container');
+                    svgNode = data.node.children[0]
+                    container.appendChild(svgNode);
+                    paper = Snap(svgNode);
+                    var bbox = paper.select('g').getBBox();
+                    paper.attr({'height': bbox.h, 'width':bbox.w});
+                    paper.zpd();
+                    // viewSelector('path[qs\\:layer="1301-Gross Building Area"]');
+                    var ele = paper.selectAll('.land').forEach(function(el){
+                        el.click(function(){
+                            paper.zoomToElement(this, 0.7, 500);
+                        });
+                    });
+                    
+                });
+
+                // UI improvement needed
+                var intervalF;
+                var clearIntervalF = function () {
+                    clearInterval(intervalF);
+                }
+                document.getElementById('location').onmousedown = function () {
+                    paper.panTo(0, 0);
+                };
+                document.getElementById('left').onmousedown = function () {
+                    paper.panTo('-10');
+                    intervalF = setInterval(function () {
+                        paper.panTo('-10');
+                    }, 100);
+                };
+                document.getElementById('left').onmouseup = clearIntervalF;
+                document.getElementById('left').onmouseleave = clearIntervalF;
+                document.getElementById('right').onmousedown = function () {
+                    paper.panTo('+10');
+                    intervalF = setInterval(function () {
+                        paper.panTo('+10');
+                    }, 100);
+                };
+                document.getElementById('right').onmouseup = clearIntervalF;
+                document.getElementById('right').onmouseleave = clearIntervalF;
+                document.getElementById('up').onmousedown = function () {
+                    paper.panTo('+0', '-10');
+                    intervalF = setInterval(function () {
+                        paper.panTo('+0', '-10');
+                    }, 100);
+                };
+                document.getElementById('up').onmouseup = clearIntervalF;
+                document.getElementById('up').onmouseleave = clearIntervalF;
+                document.getElementById('down').onmousedown = function () {
+                    paper.panTo('+0', '+10');
+                    intervalF = setInterval(function () {
+                        paper.panTo('+0', '+10');
+                    }, 100);
+                };
+                document.getElementById('down').onmouseup = clearIntervalF;
+                document.getElementById('down').onmouseleave = clearIntervalF;
+                document.getElementById('rotateL').onmousedown = function () {
+                    paper.rotate(-15);
+                    intervalF = setInterval(function () {
+                        paper.rotate(-15);
+                    }, 100);
+                };
+                document.getElementById('rotateL').onmouseup = clearIntervalF;
+                document.getElementById('rotateL').onmouseleave = clearIntervalF;
+                document.getElementById('rotateR').onmousedown = function () {
+                    paper.rotate(15);
+                    intervalF = setInterval(function () {
+                        paper.rotate(15);
+                    }, 100);
+                };
+                document.getElementById('rotateR').onmouseup = clearIntervalF;
+                document.getElementById('rotateR').onmouseleave = clearIntervalF;
+                document.getElementById('zoom2x').onmousedown = function () {
+                    paper.zoomTo(2, 400);
+                };
+                document.getElementById('zoom1x').onmousedown = function () {
+                    paper.zoomTo(1, 400);
+                };
+                document.getElementById('save').onmousedown = function () {
+                    paper.zpd('save', function (err, data) {
+                        var output = JSON.stringify(data);
+                        alert('Save Data:' + output);
+                    });
+                };
+                document.getElementById('threshold').onmousedown = function () {
+                    paper.zoomTo(1, 400);
+                    paper.zpd({ drag: true, zoomThreshold: [0.5, 3] });
+                };
+                document.onkeydown = function (e) {
+                    switch(e.keyCode) {
+                        case 37: // left
+                            paper.panTo('-10');
+                            break;
+                        case 38: // up
+                            paper.panTo('+0', '-10');
+                            break;
+                        case 39: // right
+                            paper.panTo('+10');
+                            break;
+                        case 40: // down
+                            paper.panTo('+0', '+10');
+                            break;
+                    }
+                };
+
+                document.getElementById('destroy').onmousedown = function () {
+                    paper.zpd('destroy');
+                };
+
+                document.getElementById('reapply').onmousedown = function () {
+                   applyZpd();
+                };
+
+                // settings
+                // paper.zpd({ zoom: true, pan: true, drag: true, zoomScale: 0.2 });
+                // paper.zpd(function (err, paper) { console.log(paper); });
+                // paper.zpd({ zoom: false }, function (err, paper) { console.log(paper); });
+
+                // zoomTo
+                // paper.zoomTo(1.5, 1000, mina.bounce, function (err, paper) { console.log(paper); });
+
+                // destroy
+                // paper.zpd('destroy');
+
+                // load
+                // paper.zpd({ load: {a:0.6787972450256348,b:0,c:0,d:0.6787972450256348,e:159.63783264160156,f:12.84811782836914}});
+                // 
+            }
+
+        </script>
+    </head>
+    <body>
+        <div id="svg-container"></div>
+        <div class="button">
+            <button id="location">To (0,0) Location</button>
+            <br/>
+            <button id="up">Up</button>
+            <button id="down">Down</button>
+            <br/>
+            <button id="left">Left</button>
+            <button id="right">Right</button>
+            <br/>
+
+            <button id="rotateL">Rotate -15 deg</button>
+            <button id="rotateR">Rotate 15 deg</button>
+            <br/>
+
+            <button id="zoom2x">Zoom To 2x</button>
+            <button id="zoom1x">Zoom To 1x</button>
+            <br/>
+
+            <button id="save">Save</button>
+            <button id="threshold">Zoom Threshold [0.5,3]</button>
+            <br/>
+
+            <button id="destroy">Destroy</button>
+            <button id="reapply">Re-Apply</button>
+            <br/>
+            -- or use arrow key --
+        </div>
+
+    </body>
+
+</html>


### PR DESCRIPTION
I needed to turn on and off the zpd because I had some conditional dragging of elements inside the zpd (I could only put drag on some of the elements so I can't use drag: true ) so this proved to be helpful.  Note: use http://svg.dabbles.info/snaptut-dragplugin.html for dragging that follows mouse inside zpd container