### PR TITLE
Add touch functionality to snap.svg.zpd

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ paper.zpd(function (err, paper) {
 #### zoomThreshold
 
     array: min and max zoom level threshold [min, max] (default null)
+    
+#### touch
+
+    true or false: enable or disable touch support (default true)
 
 ### More
 

--- a/snap.svg.zpd.js
+++ b/snap.svg.zpd.js
@@ -180,10 +180,63 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
             var p = svgNode.node.createSVGPoint(),
             svgPos = _findPos(svgNode.node);
 
-            p.x = event.clientX - svgPos[0];
-            p.y = event.clientY - svgPos[1];
-
+            if (typeof event.touches != 'undefined') {
+                p.x = event.touches[0].clientX - svgPos[0];
+                p.y = event.touches[0].clientY - svgPos[1];
+            } else {
+                p.x = event.clientX - svgPos[0];
+                p.y = event.clientY - svgPos[1];
+            }
+            
             return p;
+        };
+        
+        /**
+         * Detect multi-touch (i.e. pinch)
+         */
+        var _isTwoTouch = function isTwoTouch(event) {
+
+            var b = false;
+            if (typeof event.touches != 'undefined' && event.touches.length == 2) {
+                b = true;
+            }
+            
+            return b;
+        };
+        
+        /**
+         * Calculate the distance between the 1st and 2nd touches
+         */
+        var _getMultiTouchDistance = function getMultiTouchDistance(event) {
+
+            return Math.sqrt(
+                (event.touches[0].clientX - event.touches[1].clientX) * (event.touches[0].clientX - event.touches[1].clientX) +
+                (event.touches[0].clientY - event.touches[1].clientY) * (event.touches[0].clientY - event.touches[1].clientY));
+        };
+
+        /**
+         * Common function to handle the zooming for both touch and mouse wheel.
+         */
+        var _handleZoomingEvent = function handleZoomingEvent(event, zpdElement, delta) {
+
+            var z = Math.pow(1 + zpdElement.options.zoomScale, delta);
+
+            var g = zpdElement.element.node;
+
+            var p = _getEventPoint(event, zpdElement.data.svg);
+
+            p = p.matrixTransform(g.getCTM().inverse());
+
+            // Compute new scale matrix in current mouse position
+            var k = zpdElement.data.root.createSVGMatrix().translate(p.x, p.y).scale(z).translate(-p.x, -p.y);
+
+            _setCTM(g, g.getCTM().multiply(k), zpdElement.options.zoomThreshold);
+
+            if (typeof(stateTf) == 'undefined') {
+                zpdElement.data.stateTf = g.getCTM().inverse();
+            }
+
+            zpdElement.data.stateTf = zpdElement.data.stateTf.multiply(k.inverse());
         };
 
         /**
@@ -266,7 +319,9 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
                 state: 'none',
                 stateTarget: null,
                 stateOrigin: null,
-                stateTf: null
+                stateTf: null,
+                touchZoom: false,
+                prevZoomDistance: null,
             };
 
             // create an element with all required properties
@@ -290,7 +345,7 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
          */
         var _getHandlerFunctions = function getHandlerFunctions(zpdElement) {
 
-            var handleMouseUp = function handleMouseUp (event) {
+            var handleMouseOrTouchUp = function handleMouseOrTouchUp (event) {
 
                 if (event.preventDefault) {
                     event.preventDefault();
@@ -299,6 +354,9 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
                 if (!snapsvgzpd.enable) return;
 
                 event.returnValue = false;
+
+                // On touchend reset the touchZoom variable to false
+                zpdElement.data.touchZoom = false;
 
                 if (zpdElement.data.state == 'pan' || zpdElement.data.state == 'drag') {
 
@@ -309,7 +367,7 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
 
             };
 
-            var handleMouseDown = function handleMouseDown (event) {
+            var handleMouseOrTouchDown = function handleMouseOrTouchDown (event) {
 
                 if (event.preventDefault) {
                     event.preventDefault();
@@ -318,6 +376,9 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
                 if (!snapsvgzpd.enable) return;
 
                 event.returnValue = false;
+
+                // Detect if multi-touch and set touchZoom variable, this will be used in determining when to pan or zoom
+                zpdElement.data.touchZoom = _isTwoTouch(event);
 
                 var g = zpdElement.element.node;
 
@@ -403,50 +464,77 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
                     delta = event.detail / -9;       // Mozilla
                 }
 
-                var z = Math.pow(1 + zpdElement.options.zoomScale, delta);
+                _handleZoomingEvent(event, zpdElement, delta);
+            };
+            
+            var handleTouchMove = function handleTouchMove (event) {
 
-                var g = zpdElement.element.node;
-
-                var p = _getEventPoint(event, zpdElement.data.svg);
-
-                p = p.matrixTransform(g.getCTM().inverse());
-
-                // Compute new scale matrix in current mouse position
-                var k = zpdElement.data.root.createSVGMatrix().translate(p.x, p.y).scale(z).translate(-p.x, -p.y);
-
-                _setCTM(g, g.getCTM().multiply(k), zpdElement.options.zoomThreshold);
-
-                if (typeof(stateTf) == 'undefined') {
-                    zpdElement.data.stateTf = g.getCTM().inverse();
+                if (!zpdElement.options.zoom) {
+                    return;
                 }
 
-                zpdElement.data.stateTf = zpdElement.data.stateTf.multiply(k.inverse());
+                if (event.preventDefault) {
+                    event.preventDefault();
+                }
+
+                if (!snapsvgzpd.enable) return;
+
+                event.returnValue = false;
+
+                // If multi-touch is true, then we are zooming instead of panning or dragging
+                if (zpdElement.data.touchZoom) {
+
+                    var distance = _getMultiTouchDistance(event);
+
+                    if (zpdElement.data.prevZoomDistance != null) {
+                        var delta = 0;
+
+                        if (zpdElement.data.prevZoomDistance > distance) delta = -0.1111111111111111;
+                        else delta = 0.1111111111111111;
+                        
+                        _handleZoomingEvent(event, zpdElement, delta);
+                    }
+
+                    // Store the distance between touch positions so we can compare the changes to see if it's getting larger or smaller
+                    zpdElement.data.prevZoomDistance = distance;
+                } else {
+
+                    handleMouseMove (event);
+
+                }
             };
 
             return {
-                "mouseUp": handleMouseUp,
-                "mouseDown": handleMouseDown,
+                "mouseOrTouchUp": handleMouseOrTouchUp,
+                "mouseOrTouchDown": handleMouseOrTouchDown,
                 "mouseMove": handleMouseMove,
-                "mouseWheel": handleMouseWheel
+                "mouseWheel": handleMouseWheel,
+                "touchMove": handleTouchMove
             };
         };
 
 
         /**
          * Register handlers
-         * desktop and mobile (?)
+         * desktop and mobile
          */
         var _setupHandlers = function setupHandlers(svgElement, handlerFunctions) {
 
             // mobile
-            // (?)
+            if ('ontouchend' in document.documentElement) {
+            
+                svgElement.addEventListener('touchend', handlerFunctions.mouseOrTouchUp, false);
+                svgElement.addEventListener('touchcancel', handlerFunctions.mouseOrTouchUp, false);
+                svgElement.addEventListener('touchstart', handlerFunctions.mouseOrTouchDown, false);
+                // This event handles both panning and zooming
+                svgElement.addEventListener('touchmove', handlerFunctions.touchMove, false);
 
             // desktop
-            if ('onmouseup' in document.documentElement) {
+            } else if ('onmouseup' in document.documentElement) {
 
                 // IE < 9 would need to use the event onmouseup, but they do not support svg anyway..
-                svgElement.addEventListener('mouseup', handlerFunctions.mouseUp, false);
-                svgElement.addEventListener('mousedown', handlerFunctions.mouseDown, false);
+                svgElement.addEventListener('mouseup', handlerFunctions.mouseOrTouchUp, false);
+                svgElement.addEventListener('mousedown', handlerFunctions.mouseOrTouchDown, false);
                 svgElement.addEventListener('mousemove', handlerFunctions.mouseMove, false);
 
                 if (navigator.userAgent.toLowerCase().indexOf('webkit') >= 0 ||
@@ -464,17 +552,31 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
          * remove event handlers
          */
         var _tearDownHandlers = function tearDownHandlers(svgElement, handlerFunctions) {
+        
+            // mobile
+            if ('ontouchend' in document.documentElement) {
+            
+                svgElement.removeEventListener('touchend', handlerFunctions.mouseOrTouchUp, false);
+                svgElement.removeEventListener('touchcancel', handlerFunctions.mouseOrTouchUp, false);
+                svgElement.removeEventListener('touchstart', handlerFunctions.mouseOrTouchDown, false);
+                // This event handles both panning and zooming
+                svgElement.removeEventListener('touchmove', handlerFunctions.touchMove, false);
 
-            svgElement.removeEventListener('mouseup', handlerFunctions.mouseUp, false);
-            svgElement.removeEventListener('mousedown', handlerFunctions.mouseDown, false);
-            svgElement.removeEventListener('mousemove', handlerFunctions.mouseMove, false);
+            // desktop
+            } else if ('onmouseup' in document.documentElement) {
 
-            if (navigator.userAgent.toLowerCase().indexOf('webkit') >= 0 ||
-                navigator.userAgent.toLowerCase().indexOf('trident') >= 0) {
-                svgElement.removeEventListener('mousewheel', handlerFunctions.mouseWheel, false);
-            }
-            else {
-                svgElement.removeEventListener('DOMMouseScroll', handlerFunctions.mouseWheel, false);
+                svgElement.removeEventListener('mouseup', handlerFunctions.mouseOrTouchUp, false);
+                svgElement.removeEventListener('mousedown', handlerFunctions.mouseOrTouchDown, false);
+                svgElement.removeEventListener('mousemove', handlerFunctions.mouseMove, false);
+
+                if (navigator.userAgent.toLowerCase().indexOf('webkit') >= 0 ||
+                    navigator.userAgent.toLowerCase().indexOf('trident') >= 0) {
+                    svgElement.removeEventListener('mousewheel', handlerFunctions.mouseWheel, false);
+                }
+                else {
+                    svgElement.removeEventListener('DOMMouseScroll', handlerFunctions.mouseWheel, false);
+                }
+
             }
         };
 

--- a/snap.svg.zpd.js
+++ b/snap.svg.zpd.js
@@ -378,7 +378,7 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
                 event.returnValue = false;
 
                 // Detect if multi-touch and set touchZoom variable, this will be used in determining when to pan or zoom
-                zpdElement.data.touchZoom = _isTwoTouch(event);
+                if (zpdElement.options.touch) zpdElement.data.touchZoom = _isTwoTouch(event);
 
                 var g = zpdElement.element.node;
 
@@ -469,7 +469,7 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
             
             var handleTouchMove = function handleTouchMove (event) {
 
-                if (!zpdElement.options.zoom) {
+                if (!zpdElement.options.zoom || !zpdElement.options.touch) {
                     return;
                 }
 
@@ -588,11 +588,12 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
 
             // define some custom options
             var zpdOptions = {
-                pan: true,          // enable or disable panning (default enabled)
-                zoom: true,         // enable or disable zooming (default enabled)
-                drag: false,        // enable or disable dragging (default disabled)
-                zoomScale: 0.2,     // define zoom sensitivity
-                zoomThreshold: null // define zoom threshold
+                pan: true,           // enable or disable panning (default enabled)
+                zoom: true,          // enable or disable zooming (default enabled)
+                drag: false,         // enable or disable dragging (default disabled)
+                zoomScale: 0.2,      // define zoom sensitivity
+                zoomThreshold: null, // define zoom threshold
+                touch: true          // enable or disable touch (default enabled)
             };
 
             // the situation event of zpd, may be init, reinit, destroy, save, origin, toggle

--- a/snap.svg.zpd.js
+++ b/snap.svg.zpd.js
@@ -489,8 +489,8 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
                     if (zpdElement.data.prevZoomDistance != null) {
                         var delta = 0;
 
-                        if (zpdElement.data.prevZoomDistance > distance) delta = -0.1111111111111111;
-                        else delta = 0.1111111111111111;
+                        if (zpdElement.data.prevZoomDistance > distance) delta = -0.15;
+                        else delta = 0.15;
                         
                         _handleZoomingEvent(event, zpdElement, delta);
                     }

--- a/snap.svg.zpd.js
+++ b/snap.svg.zpd.js
@@ -180,63 +180,10 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
             var p = svgNode.node.createSVGPoint(),
             svgPos = _findPos(svgNode.node);
 
-            if (typeof event.touches != 'undefined') {
-                p.x = event.touches[0].clientX - svgPos[0];
-                p.y = event.touches[0].clientY - svgPos[1];
-            } else {
-                p.x = event.clientX - svgPos[0];
-                p.y = event.clientY - svgPos[1];
-            }
-            
+            p.x = event.clientX - svgPos[0];
+            p.y = event.clientY - svgPos[1];
+
             return p;
-        };
-        
-        /**
-         * Detect multi-touch (i.e. pinch)
-         */
-        var _isTwoTouch = function isTwoTouch(event) {
-
-            var b = false;
-            if (typeof event.touches != 'undefined' && event.touches.length == 2) {
-                b = true;
-            }
-            
-            return b;
-        };
-        
-        /**
-         * Calculate the distance between the 1st and 2nd touches
-         */
-        var _getMultiTouchDistance = function getMultiTouchDistance(event) {
-
-            return Math.sqrt(
-                (event.touches[0].clientX - event.touches[1].clientX) * (event.touches[0].clientX - event.touches[1].clientX) +
-                (event.touches[0].clientY - event.touches[1].clientY) * (event.touches[0].clientY - event.touches[1].clientY));
-        };
-
-        /**
-         * Common function to handle the zooming for both touch and mouse wheel.
-         */
-        var _handleZoomingEvent = function handleZoomingEvent(event, zpdElement, delta) {
-
-            var z = Math.pow(1 + zpdElement.options.zoomScale, delta);
-
-            var g = zpdElement.element.node;
-
-            var p = _getEventPoint(event, zpdElement.data.svg);
-
-            p = p.matrixTransform(g.getCTM().inverse());
-
-            // Compute new scale matrix in current mouse position
-            var k = zpdElement.data.root.createSVGMatrix().translate(p.x, p.y).scale(z).translate(-p.x, -p.y);
-
-            _setCTM(g, g.getCTM().multiply(k), zpdElement.options.zoomThreshold);
-
-            if (typeof(stateTf) == 'undefined') {
-                zpdElement.data.stateTf = g.getCTM().inverse();
-            }
-
-            zpdElement.data.stateTf = zpdElement.data.stateTf.multiply(k.inverse());
         };
 
         /**
@@ -319,9 +266,7 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
                 state: 'none',
                 stateTarget: null,
                 stateOrigin: null,
-                stateTf: null,
-                touchZoom: false,
-                prevZoomDistance: null,
+                stateTf: null
             };
 
             // create an element with all required properties
@@ -345,7 +290,7 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
          */
         var _getHandlerFunctions = function getHandlerFunctions(zpdElement) {
 
-            var handleMouseOrTouchUp = function handleMouseOrTouchUp (event) {
+            var handleMouseUp = function handleMouseUp (event) {
 
                 if (event.preventDefault) {
                     event.preventDefault();
@@ -354,9 +299,6 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
                 if (!snapsvgzpd.enable) return;
 
                 event.returnValue = false;
-
-                // On touchend reset the touchZoom variable to false
-                zpdElement.data.touchZoom = false;
 
                 if (zpdElement.data.state == 'pan' || zpdElement.data.state == 'drag') {
 
@@ -367,7 +309,7 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
 
             };
 
-            var handleMouseOrTouchDown = function handleMouseOrTouchDown (event) {
+            var handleMouseDown = function handleMouseDown (event) {
 
                 if (event.preventDefault) {
                     event.preventDefault();
@@ -376,9 +318,6 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
                 if (!snapsvgzpd.enable) return;
 
                 event.returnValue = false;
-
-                // Detect if multi-touch and set touchZoom variable, this will be used in determining when to pan or zoom
-                zpdElement.data.touchZoom = _isTwoTouch(event);
 
                 var g = zpdElement.element.node;
 
@@ -464,77 +403,50 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
                     delta = event.detail / -9;       // Mozilla
                 }
 
-                _handleZoomingEvent(event, zpdElement, delta);
-            };
-            
-            var handleTouchMove = function handleTouchMove (event) {
+                var z = Math.pow(1 + zpdElement.options.zoomScale, delta);
 
-                if (!zpdElement.options.zoom) {
-                    return;
+                var g = zpdElement.element.node;
+
+                var p = _getEventPoint(event, zpdElement.data.svg);
+
+                p = p.matrixTransform(g.getCTM().inverse());
+
+                // Compute new scale matrix in current mouse position
+                var k = zpdElement.data.root.createSVGMatrix().translate(p.x, p.y).scale(z).translate(-p.x, -p.y);
+
+                _setCTM(g, g.getCTM().multiply(k), zpdElement.options.zoomThreshold);
+
+                if (typeof(stateTf) == 'undefined') {
+                    zpdElement.data.stateTf = g.getCTM().inverse();
                 }
 
-                if (event.preventDefault) {
-                    event.preventDefault();
-                }
-
-                if (!snapsvgzpd.enable) return;
-
-                event.returnValue = false;
-
-                // If multi-touch is true, then we are zooming instead of panning or dragging
-                if (zpdElement.data.touchZoom) {
-
-                    var distance = _getMultiTouchDistance(event);
-
-                    if (zpdElement.data.prevZoomDistance != null) {
-                        var delta = 0;
-
-                        if (zpdElement.data.prevZoomDistance > distance) delta = -0.1111111111111111;
-                        else delta = 0.1111111111111111;
-                        
-                        _handleZoomingEvent(event, zpdElement, delta);
-                    }
-
-                    // Store the distance between touch positions so we can compare the changes to see if it's getting larger or smaller
-                    zpdElement.data.prevZoomDistance = distance;
-                } else {
-
-                    handleMouseMove (event);
-
-                }
+                zpdElement.data.stateTf = zpdElement.data.stateTf.multiply(k.inverse());
             };
 
             return {
-                "mouseOrTouchUp": handleMouseOrTouchUp,
-                "mouseOrTouchDown": handleMouseOrTouchDown,
+                "mouseUp": handleMouseUp,
+                "mouseDown": handleMouseDown,
                 "mouseMove": handleMouseMove,
-                "mouseWheel": handleMouseWheel,
-                "touchMove": handleTouchMove
+                "mouseWheel": handleMouseWheel
             };
         };
 
 
         /**
          * Register handlers
-         * desktop and mobile
+         * desktop and mobile (?)
          */
         var _setupHandlers = function setupHandlers(svgElement, handlerFunctions) {
 
             // mobile
-            if ('ontouchend' in document.documentElement) {
-            
-                svgElement.addEventListener('touchend', handlerFunctions.mouseOrTouchUp, false);
-                svgElement.addEventListener('touchcancel', handlerFunctions.mouseOrTouchUp, false);
-                svgElement.addEventListener('touchstart', handlerFunctions.mouseOrTouchDown, false);
-                // This event handles both panning and zooming
-                svgElement.addEventListener('touchmove', handlerFunctions.touchMove, false);
+            // (?)
 
             // desktop
-            } else if ('onmouseup' in document.documentElement) {
+            if ('onmouseup' in document.documentElement) {
 
                 // IE < 9 would need to use the event onmouseup, but they do not support svg anyway..
-                svgElement.addEventListener('mouseup', handlerFunctions.mouseOrTouchUp, false);
-                svgElement.addEventListener('mousedown', handlerFunctions.mouseOrTouchDown, false);
+                svgElement.addEventListener('mouseup', handlerFunctions.mouseUp, false);
+                svgElement.addEventListener('mousedown', handlerFunctions.mouseDown, false);
                 svgElement.addEventListener('mousemove', handlerFunctions.mouseMove, false);
 
                 if (navigator.userAgent.toLowerCase().indexOf('webkit') >= 0 ||
@@ -552,31 +464,17 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
          * remove event handlers
          */
         var _tearDownHandlers = function tearDownHandlers(svgElement, handlerFunctions) {
-        
-            // mobile
-            if ('ontouchend' in document.documentElement) {
-            
-                svgElement.removeEventListener('touchend', handlerFunctions.mouseOrTouchUp, false);
-                svgElement.removeEventListener('touchcancel', handlerFunctions.mouseOrTouchUp, false);
-                svgElement.removeEventListener('touchstart', handlerFunctions.mouseOrTouchDown, false);
-                // This event handles both panning and zooming
-                svgElement.removeEventListener('touchmove', handlerFunctions.touchMove, false);
 
-            // desktop
-            } else if ('onmouseup' in document.documentElement) {
+            svgElement.removeEventListener('mouseup', handlerFunctions.mouseUp, false);
+            svgElement.removeEventListener('mousedown', handlerFunctions.mouseDown, false);
+            svgElement.removeEventListener('mousemove', handlerFunctions.mouseMove, false);
 
-                svgElement.removeEventListener('mouseup', handlerFunctions.mouseOrTouchUp, false);
-                svgElement.removeEventListener('mousedown', handlerFunctions.mouseOrTouchDown, false);
-                svgElement.removeEventListener('mousemove', handlerFunctions.mouseMove, false);
-
-                if (navigator.userAgent.toLowerCase().indexOf('webkit') >= 0 ||
-                    navigator.userAgent.toLowerCase().indexOf('trident') >= 0) {
-                    svgElement.removeEventListener('mousewheel', handlerFunctions.mouseWheel, false);
-                }
-                else {
-                    svgElement.removeEventListener('DOMMouseScroll', handlerFunctions.mouseWheel, false);
-                }
-
+            if (navigator.userAgent.toLowerCase().indexOf('webkit') >= 0 ||
+                navigator.userAgent.toLowerCase().indexOf('trident') >= 0) {
+                svgElement.removeEventListener('mousewheel', handlerFunctions.mouseWheel, false);
+            }
+            else {
+                svgElement.removeEventListener('DOMMouseScroll', handlerFunctions.mouseWheel, false);
             }
         };
 

--- a/snap.svg.zpd.js
+++ b/snap.svg.zpd.js
@@ -481,21 +481,22 @@ SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformTo
 
                 event.returnValue = false;
 
-                // If multi-touch is true, then we are zooming instead of panning or dragging
+                // If multi-touch is true, then we are zooming instead of panning or dragging.
                 if (zpdElement.data.touchZoom) {
 
                     var distance = _getMultiTouchDistance(event);
 
                     if (zpdElement.data.prevZoomDistance != null) {
-                        var delta = 0;
+                        // The delta value is set to 0.15 as it best matches the zoom sensitivity in browsers. Use zoomScale option to change the zoom sensitivity.
+                        var delta = 0.15; // Case for the pinch being opened.
 
-                        if (zpdElement.data.prevZoomDistance > distance) delta = -0.15;
-                        else delta = 0.15;
+                        // Case for pinch being closed, make the delta negative
+                        if (zpdElement.data.prevZoomDistance > distance) delta = delta * -1;
                         
                         _handleZoomingEvent(event, zpdElement, delta);
                     }
 
-                    // Store the distance between touch positions so we can compare the changes to see if it's getting larger or smaller
+                    // Store the distance between touch positions so we can compare the changes to see if it's getting larger or smaller.
                     zpdElement.data.prevZoomDistance = distance;
                 } else {
 


### PR DESCRIPTION
- Add single touch panning and dragging.
- Add multi-touch zooming for 2 touches only. This can be changed to work for more touches by changing this line 'event.touches.length == 2'. Be aware that the zooming calculation will only work based off the first 2 touches.